### PR TITLE
Handle requiring the file in the library itself

### DIFF
--- a/lib/flattenator.rb
+++ b/lib/flattenator.rb
@@ -1,6 +1,6 @@
+require "flattenator/hash"
 require "flattenator/version"
 
 module Flattenator
-  class Error < StandardError; end
-  # Your code goes here...
+  Error = Class.new(StandardError)
 end

--- a/test/flattenator/hash_test.rb
+++ b/test/flattenator/hash_test.rb
@@ -1,5 +1,4 @@
 require "test_helper"
-require "flattenator/hash"
 
 class HashLike
   def each_pair

--- a/test/flattenator/hash_test.rb
+++ b/test/flattenator/hash_test.rb
@@ -134,10 +134,6 @@ describe Flattenator::Hash do
           "banana",
         ],
       }
-      flattened = {
-        "bing" => JSON.dump(source[:bing]),
-        "fruits" => JSON.dump(source[:fruits]),
-      }
       subject = Flattenator::Hash.new(source, include_unflattened: false)
 
       refute subject.flattened.include?("bing")


### PR DESCRIPTION
Because:

* When I tried to use this in another app, I got an UnintializedConstant exception, because `lib/flattenator/hash.rb` wasn't being included.

This PR:

* Moves the require to `lib/flattenator.rb` instead of the test.
* Removes that unused variable from a test, per a Ruby warning