### PR TITLE
Move definition of Flattenator module to top

### DIFF
--- a/lib/flattenator.rb
+++ b/lib/flattenator.rb
@@ -1,6 +1,5 @@
+module Flattenator
+end
+
 require "flattenator/hash"
 require "flattenator/version"
-
-module Flattenator
-  Error = Class.new(StandardError)
-end


### PR DESCRIPTION
Because:

* When loading this into another app, `Flattenator::Hash` tripped up saying that `Flattenator` wasn't defined.

This PR:

* Moves the definition of `Flattenator` module above the `Flattenator::Hash` definition.